### PR TITLE
Fix two warnings Title underline too short

### DIFF
--- a/docs/protocol_details.rst
+++ b/docs/protocol_details.rst
@@ -254,7 +254,7 @@ Real time LED operating mode
 3. After some time without any UDP datagrams device switches back to movie mode.
 
 Real time LED UDP datagram format
--------------------------------
+---------------------------------
 
 Before datagrams are sent to a device application needs to login and verify authentication token. See above.
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -913,7 +913,7 @@ The response will be an object.
 	(integer)
 
 Delete layout
-----------
+-------------
 
 HTTP request
 ````````````


### PR DESCRIPTION
They appear when building by Sphinx-build.