### PR TITLE
Document Application code 1106

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -148,6 +148,9 @@ The API may return application status as `code` value of JSON. Returned will not
 1105
 	Invalid argument key
 
+1106
+	Error - value too short? (e.g. `movies/full` does not have as many pixels as `frames_number * leds_per_frame`).
+
 1107
 	Ok?
 


### PR DESCRIPTION
```
###
@new-movie = {{$uuid}}
POST {{host}}/xled/v1/movies/new
X-Auth-Token: {{token}}
Content-Type: application/json
Accept: application/json

{
	"descriptor_type": "rgb_raw",
	"fps": 40,
	"frames_number": 40,
	"id": 0,
	"leds_per_frame": 200,
	"name": "Heart",
	"unique_id": "{{new-movie}}"
}

###
POST {{host}}/xled/v1/movies/full
X-Auth-Token: {{token}}
Content-Type: application/octet-stream
Accept: application/json

< movies/generated.raw
```

I got 1106 when `generated.raw` was only 200 (leds) * 30 (frames) * 3 (rgb) long.